### PR TITLE
feat: getAuthIdentifier() support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Return a `JwtUser` instance from `JwtGuard` instead of `GenericUser` (`JwtUser` is a subclass of `GenericUser` to prevent a breaking change) with support for returning the value of `sub` from `getAuthIdentifier()`.
+
 
 ## [2.0.0] - 2020-04-15
 

--- a/src/JwtGuard.php
+++ b/src/JwtGuard.php
@@ -3,7 +3,6 @@
 namespace Butler\Auth;
 
 use Exception;
-use Illuminate\Auth\GenericUser;
 use Illuminate\Auth\GuardHelpers;
 use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Auth\UserProvider;
@@ -189,6 +188,6 @@ class JwtGuard implements Guard
             return $this->provider->retrieveById($token->getClaim('sub'));
         }
 
-        return new GenericUser($token->getClaims());
+        return new JwtUser($token->getClaims());
     }
 }

--- a/src/JwtUser.php
+++ b/src/JwtUser.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Butler\Auth;
+
+use Illuminate\Auth\GenericUser;
+
+class JwtUser extends GenericUser
+{
+    public function getAuthIdentifierName()
+    {
+        return 'sub';
+    }
+}

--- a/tests/JwtGuardTest.php
+++ b/tests/JwtGuardTest.php
@@ -3,6 +3,7 @@
 namespace Butler\Auth\Tests;
 
 use Butler\Auth\JwtGuard;
+use Butler\Auth\JwtUser;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Http\Request;
@@ -76,6 +77,19 @@ class JwtGuardTest extends TestCase
         $guard = new JwtGuard($request, 'key', []);
 
         $this->assertEquals('subject', $guard->user()->sub);
+    }
+
+    public function test_user_returns_user_returning_sub_for_getAuthIdentifier()
+    {
+        $token = (new Builder())
+            ->setSubject('subject')
+            ->sign(new Sha256(), 'key')
+            ->getToken();
+
+        $request = Request::create('/', 'GET', [], [], [], ['HTTP_AUTHORIZATION' => "Bearer {$token}"]);
+        $guard = new JwtGuard($request, 'key', []);
+
+        $this->assertEquals('subject', $guard->user()->getAuthIdentifier());
     }
 
     public function test_user_returns_user_with_token_in_query()


### PR DESCRIPTION
Return a `JwtUser` instance from `JwtGuard` instead of `GenericUser` (`JwtUser` is a subclass of `GenericUser` to prevent a breaking change) with support for returning the value of `sub` from `getAuthIdentifier()`.