### PR TITLE
Add explicit table name for AccessToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Add explicit table name to `AccessToken` to prevent implicit lookup through pluralization.
+
 
 ## [7.1.0] - 2025-05-13
 

--- a/src/AccessToken.php
+++ b/src/AccessToken.php
@@ -24,6 +24,8 @@ class AccessToken extends Model implements HasAbilities
         'token',
     ];
 
+    protected $table = 'access_tokens';
+
     protected static function booted()
     {
         static::deleted(function ($accessToken) {


### PR DESCRIPTION
This is to prevent implicit table name lookup through the `Illuminate\Support\Pluralizer` flow which adds unnecessary milliseconds to every request.